### PR TITLE
feat: make admin position sidebar fields useable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.5
+
+### Features
+
+- fields from the `{admin: {position:'sidebar'}}` are now useable. (in the main fields area)
+
 ## 0.0.4
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # Payload Visual Editor Plugin
-This plugin provides a visual editor, including a nice UI, for [Payload](https://github.com/payloadcms/payload) collections.
+This plugin provides a visual editor, including a nice UI, for [Payload](https://github.com/payloadcms/payload).
 
 > **Note**
 > This plugin is currently under active development and still in alpha stage. Please check back periodically for updates.
 
 ## Core features:
 
-- Adds a visual editor component to your collections:
+- Adds a visual editor component to your collections and globals:
   - Creates the visual editor UI in the Admin UIs edit view
   - Handles the live data exchange with your frontend 
 
 ![image](https://github.com/pemedia/payload-visual-live-preview/blob/main/visual-editor-screenshot.png?raw=true)
 
-> **Warning**
-> In the Admin UI of the collections in which you use the visual editor plugin, you cannot use any elements in the `{admin: {position:'sidebar'}}` because for now we have to hide this area of the sidebar, to make the preview UI work. But we are elaborating on options to solve this in the future.
+> **Note**
+> For the collections in which you use the visual editor, fields in the `{admin: {position:'sidebar'}}` area will be rendered below all other fields, in the "main" area.
 
 ## Installation
 

--- a/example/cms/src/collections/Posts.ts
+++ b/example/cms/src/collections/Posts.ts
@@ -5,6 +5,11 @@ export const Posts: CollectionConfig = {
     slug: "posts",
     fields: [
         {
+            name: "title",
+            type: "text",
+            required: true,
+        },
+        {
             name: "subtitle",
             type: "text",
             required: true,
@@ -15,6 +20,13 @@ export const Posts: CollectionConfig = {
             relationTo: Tags.slug,
             hasMany: true,
             required: true,
+        },
+        {
+            name: "description",
+            type: "text",
+            admin: {
+                position: 'sidebar'
+            }
         },
     ],
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "payload-visual-editor",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Payload CMS plugin which provides a visual live editor directly in the Admin UI.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/visualEditor/index.tsx
+++ b/src/components/visualEditor/index.tsx
@@ -9,6 +9,10 @@ import React, { MouseEvent as ReactMouseEvent, useEffect, useRef, useState } fro
 import { generateDocument } from "../../utils/generateDocument";
 import { useResizeObserver } from "./useResizeObserver";
 
+import RenderFields from 'payload/dist/admin/components/forms/RenderFields';
+import fieldTypes from 'payload/dist/admin/components/forms/field-types';
+
+
 const SCREEN_SIZES = {
     desktop: {
         width: "100%",
@@ -129,6 +133,18 @@ export const VisualEditor = (config: Config) => () => {
 
     return (
         <>
+            {(fieldConfigs.filter(e => e.admin?.position === 'sidebar').length > 0) ? (
+            <div className="ContentEditorAdminSidebar">
+                <RenderFields
+                    readOnly={false}
+                    permissions={documentInfo.docPermissions?.fields}
+                    filter={(field) => field?.admin?.position === 'sidebar'}
+                    fieldTypes={fieldTypes}
+                    fieldSchema={fieldConfigs}
+                />
+            </div>
+            ) : null }
+
             <button className="toggleVisualEditor menu pill pill--has-action" type="button" onClick={togglePreview}>
                 <Edit /> Live Preview
             </button>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -13,6 +13,10 @@
   display: none;
 }
 
+.ContentEditorAdminSidebar {
+  display:none;
+}
+
 @media (min-width: calc($breakpoint-m-width + 1px)) {
   .collection-edit.visual-editor,
   .global-edit.visual-editor {
@@ -113,8 +117,14 @@
         }
 
         > .render-fields {
+
           position: relative;
     
+          > .field-type {
+            padding-left: var(--gutter-h);
+            padding-right: var(--gutter-h);
+          }
+
           .toggleVisualEditor.menu {
             display:block;
             position: absolute;
@@ -168,6 +178,20 @@
         }
       }
     }
+
+    /* ------------------------------- */
+    /* --- Admin Position: Sidebar --- */
+    /* ------------------------------- */
+
+    .ContentEditorAdminSidebar {
+      display:block;
+      border: 1px solid var(--theme-elevation-100);
+      background-color: var(--theme-elevation-50) ;
+      padding: base(1);
+      padding-left: var(--gutter-h);
+      padding-right: var(--gutter-h);
+    }
+
   }
   
   .collection-edit.visual-editor.show-preview,
@@ -226,6 +250,7 @@
       
     .ContentEditor {
       display:flex;
+      padding:0 !important;
 
       > .live-preview-container {
         display: flex;
@@ -315,11 +340,16 @@
     }
 
     .sidebar-drag-handle {
-      width: 5px;
+      width: 2px;
       height:100%;
       background: var(--theme-elevation-0);
       border-right: 2px solid var(--theme-elevation-200);
       cursor:col-resize;
+    }
+
+    .ContentEditorAdminSidebar {
+      border-left: none;
+      border-right: none;
     }
   }
 }


### PR DESCRIPTION
Making the fields in the `admin: { position: 'sidebar' }` area usable again. Inserting them at the bottom of the main fields area with Payloads native <RenderFields> component. Added a field to test it out in the example code.

@DennisSnijder: Would you check it out?