### PR TITLE
Feat admin sidebar tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This plugin provides a visual editor, including a nice UI, for [Payload](https:/
 ![image](https://github.com/pemedia/payload-visual-live-preview/blob/main/visual-editor-screenshot.png?raw=true)
 
 > **Note**
-> For the collections in which you use the visual editor, fields in the `{admin: {position:'sidebar'}}` area will be rendered below all other fields, in the "main" area.
+> For the collections in which you use the visual editor, fields in the `{admin: {position:'sidebar'}}` area will be rendered below all other fields, in the "main" area or, if you are using tabs, in an extra tab called "More".
 
 ## Installation
 

--- a/example/cms/src/collections/Posts.ts
+++ b/example/cms/src/collections/Posts.ts
@@ -5,21 +5,30 @@ export const Posts: CollectionConfig = {
     slug: "posts",
     fields: [
         {
-            name: "title",
-            type: "text",
-            required: true,
-        },
-        {
-            name: "subtitle",
-            type: "text",
-            required: true,
-        },
-        {
-            name: "tags",
-            type: "relationship",
-            relationTo: Tags.slug,
-            hasMany: true,
-            required: true,
+            type: 'tabs',
+            tabs: [
+                {
+                label: 'General',
+                fields: [
+                    {
+                        name: "title",
+                        type: "text",
+                        required: true,
+                    },
+                    {
+                        name: "subtitle",
+                        type: "text",
+                        required: true,
+                    },
+                    {
+                        name: "tags",
+                        type: "relationship",
+                        relationTo: Tags.slug,
+                        hasMany: true,
+                        required: true,
+                    },
+                ]
+            }]
         },
         {
             name: "description",
@@ -28,5 +37,6 @@ export const Posts: CollectionConfig = {
                 position: 'sidebar'
             }
         },
+        
     ],
 };

--- a/src/components/visualEditor/index.tsx
+++ b/src/components/visualEditor/index.tsx
@@ -1,3 +1,6 @@
+import React, { MouseEvent as ReactMouseEvent, useEffect, useRef, useState } from "react";
+import { useTranslation } from 'react-i18next';
+
 import { useAllFormFields } from "payload/components/forms";
 import { useDocumentInfo } from "payload/components/utilities";
 import { Fields } from "payload/dist/admin/components/forms/Form/types";
@@ -5,12 +8,15 @@ import CloseMenu from "payload/dist/admin/components/icons/CloseMenu";
 import Edit from "payload/dist/admin/components/icons/Edit";
 import { ContextType } from "payload/dist/admin/components/utilities/DocumentInfo/types";
 import { Field } from "payload/types";
-import React, { MouseEvent as ReactMouseEvent, useEffect, useRef, useState } from "react";
 import { generateDocument } from "../../utils/generateDocument";
 import { useResizeObserver } from "./useResizeObserver";
 
 import RenderFields from 'payload/dist/admin/components/forms/RenderFields';
 import fieldTypes from 'payload/dist/admin/components/forms/field-types';
+
+import CopyToClipboard from 'payload/dist/admin/components/elements/CopyToClipboard';
+import { useConfig } from 'payload/components/utilities';
+
 
 
 const SCREEN_SIZES = {
@@ -178,11 +184,20 @@ export const VisualEditor = (config: Config) => () => {
 export const AdminSidebar = () => {
     const documentInfo = useDocumentInfo();
     const fieldConfigs = getFieldConfigs(documentInfo);
+    const baseClass = 'collection-edit';
+
+    const { 
+        serverURL,
+        routes: { api } 
+    } = useConfig();
+
+    const collection = documentInfo.collection;
+    const apiURL = `${serverURL}${api}/${collection?.slug}/${documentInfo.id}${collection?.versions?.drafts ? '?draft=true' : ''}`;
 
     return (
-        <>
-            {(fieldConfigs.filter(e => e.admin?.position === 'sidebar').length > 0) ? (
             <div className="ContentEditorAdminSidebar">
+
+                {(fieldConfigs.filter(e => e.admin?.position === 'sidebar').length > 0) ? (
                 <RenderFields
                     readOnly={false}
                     permissions={documentInfo.docPermissions?.fields}
@@ -190,9 +205,25 @@ export const AdminSidebar = () => {
                     fieldTypes={fieldTypes}
                     fieldSchema={fieldConfigs}
                 />
-            </div>
-            ) : null }
-        </>
+                ) : null }
+
+                <ul className={`${baseClass}__meta`}>
+                    <li className={`${baseClass}__api-url`}>
+                        <span className={`${baseClass}__label`}>
+                            API URL
+                            {' '}
+                            <CopyToClipboard value={apiURL} />
+                        </span>
+                        <a
+                            href={apiURL}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            {apiURL}
+                        </a>
+                    </li>
+                </ul>
+        </div>
     )
 };
 

--- a/src/components/visualEditor/index.tsx
+++ b/src/components/visualEditor/index.tsx
@@ -133,18 +133,6 @@ export const VisualEditor = (config: Config) => () => {
 
     return (
         <>
-            {(fieldConfigs.filter(e => e.admin?.position === 'sidebar').length > 0) ? (
-            <div className="ContentEditorAdminSidebar">
-                <RenderFields
-                    readOnly={false}
-                    permissions={documentInfo.docPermissions?.fields}
-                    filter={(field) => field?.admin?.position === 'sidebar'}
-                    fieldTypes={fieldTypes}
-                    fieldSchema={fieldConfigs}
-                />
-            </div>
-            ) : null }
-
             <button className="toggleVisualEditor menu pill pill--has-action" type="button" onClick={togglePreview}>
                 <Edit /> Live Preview
             </button>
@@ -185,3 +173,26 @@ export const VisualEditor = (config: Config) => () => {
         </>
     );
 };
+
+
+export const AdminSidebar = () => {
+    const documentInfo = useDocumentInfo();
+    const fieldConfigs = getFieldConfigs(documentInfo);
+
+    return (
+        <>
+            {(fieldConfigs.filter(e => e.admin?.position === 'sidebar').length > 0) ? (
+            <div className="ContentEditorAdminSidebar">
+                <RenderFields
+                    readOnly={false}
+                    permissions={documentInfo.docPermissions?.fields}
+                    filter={(field) => field?.admin?.position === 'sidebar'}
+                    fieldTypes={fieldTypes}
+                    fieldSchema={fieldConfigs}
+                />
+            </div>
+            ) : null }
+        </>
+    )
+};
+

--- a/src/fields/adminSidebarField.ts
+++ b/src/fields/adminSidebarField.ts
@@ -1,0 +1,14 @@
+import { Field } from "payload/types";
+import { AdminSidebar } from "../components/visualEditor";
+
+export const createAdminSidebarField = (): Field => {
+    return {
+        name: "adminsidebar",
+        type: "ui",
+        admin: {
+            components: {
+                Field: AdminSidebar,
+            },
+        },
+    };
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { Config } from "payload/config";
 import { createVisualEditorField } from "./fields/visualEditorField";
+import { createAdminSidebarField } from "./fields/adminSidebarField";
 import { CollectionConfig, GlobalConfig } from "payload/types";
 
 type CollectionOrGlobalConfig = CollectionConfig | GlobalConfig;
@@ -22,13 +23,46 @@ const extendCogConfigs = <T extends CollectionOrGlobalConfig>(
     const pluginCogConfig = pluginCogConfigs?.[cogConfig.slug];
 
     if (pluginCogConfig) {
-        return {
-            ...cogConfig,
-            fields: [
-                ...cogConfig.fields,
-                createVisualEditorField(pluginCogConfig.previewUrl ?? previewUrl),
-            ],
-        };
+
+        const tabsIndex = cogConfig.fields.findIndex(e => e.type === 'tabs');
+        const hasTabs = (tabsIndex > -1) ? true : false;
+
+        if(hasTabs) {
+
+            let fields = cogConfig.fields;
+            let tabsContent = fields[tabsIndex];
+            tabsContent.tabs = [
+                ...tabsContent.tabs,
+                {
+                    label: 'More',
+                    fields: [
+                        createAdminSidebarField()
+                    ]
+                },  
+            ]
+            fields[tabsIndex] = tabsContent;
+
+            return {
+                ...cogConfig,
+                fields: [
+                    ...fields,
+                    createVisualEditorField(pluginCogConfig.previewUrl ?? previewUrl),
+                ],
+            };
+
+        } else {
+
+            return {
+                ...cogConfig,
+                fields: [
+                    ...cogConfig.fields,
+                    createAdminSidebarField(),
+                    createVisualEditorField(pluginCogConfig.previewUrl ?? previewUrl),
+                ],
+            };
+
+        }
+
     }
 
     return cogConfig

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -13,9 +13,25 @@
   display: none;
 }
 
-.ContentEditorAdminSidebar {
-  display:none;
+
+/* --------------------------------- */
+/* --- Hide admin sidebar fields --- */
+/* --------------------------------- */
+
+.collection-edit.visual-editor,
+.global-edit.visual-editor {
+
+  .collection-edit__sidebar-sticky-wrap,
+  .global-edit__sidebar-sticky-wrap {
+
+    .collection-edit__sidebar-fields,
+    .global-edit__sidebar-fields {
+      display:none;
+    }
+  }
+
 }
+
 
 @media (min-width: calc($breakpoint-m-width + 1px)) {
   .collection-edit.visual-editor,
@@ -183,7 +199,7 @@
     /* --- Admin Position: Sidebar --- */
     /* ------------------------------- */
 
-    .ContentEditorAdminSidebar {
+    .collection-edit__edit > .render-fields > .ContentEditorAdminSidebar {
       display:block;
       border: 1px solid var(--theme-elevation-100);
       background-color: var(--theme-elevation-50) ;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -208,15 +208,19 @@
     /* --- Admin Position: Sidebar --- */
     /* ------------------------------- */
 
-    .collection-edit__edit > .render-fields > .ContentEditorAdminSidebar {
-      display:block;
-      border: 1px solid var(--theme-elevation-100);
-      background-color: var(--theme-elevation-50) ;
-      padding: base(1);
-      padding-left: var(--gutter-h);
-      padding-right: var(--gutter-h);
+    .collection-edit__edit > .render-fields {
 
-    }
+      > .ContentEditorAdminSidebar {
+        display:block;
+        border: 1px solid var(--theme-elevation-100);
+        background-color: var(--theme-elevation-50) ;
+        padding: base(1);
+        padding-left: var(--gutter-h);
+        padding-right: var(--gutter-h);
+        margin-top:auto;
+      }
+
+    } 
 
     .tabs-field__tabs:after {
       width: 0;
@@ -377,9 +381,16 @@
       cursor:col-resize;
     }
 
-    .ContentEditorAdminSidebar {
-      border-left: none;
-      border-right: none;
+    .collection-edit__edit > .render-fields {
+
+      display: flex;
+      flex-direction: column;
+
+      > .ContentEditorAdminSidebar {
+        border-left: none;
+        border-right: none;
+        margin-top: auto;
+      }
     }
   }
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -32,6 +32,15 @@
 
 }
 
+.ContentEditorAdminSidebar {
+
+  .collection-edit__meta {
+    padding:0;
+  }
+
+}
+
+
 
 @media (min-width: calc($breakpoint-m-width + 1px)) {
   .collection-edit.visual-editor,
@@ -206,6 +215,7 @@
       padding: base(1);
       padding-left: var(--gutter-h);
       padding-right: var(--gutter-h);
+
     }
 
     .tabs-field__tabs:after {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -208,6 +208,10 @@
       padding-right: var(--gutter-h);
     }
 
+    .tabs-field__tabs:after {
+      width: 0;
+    }
+
   }
   
   .collection-edit.visual-editor.show-preview,


### PR DESCRIPTION
Integrating the content from `admin: { position: "sidebar" }` into a separate tab, in the main field area, if tabs are set up in the collection config. Otherwise, the content gets placed at the bottom of the general field area.

Would you have a look @dkirchhof ?