### PR TITLE
[Bugfix] Added react-i18next as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
   ],
   "peerDependencies": {
     "payload": "^1.9.0",
-    "react": "^18.2.0"
+    "react": "^18.2.0",
+    "react-i18next": "^11.18.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.9",


### PR DESCRIPTION
# Context
When installing the new 0.1.1, I get the error "could not find module react-i18next". 
This is because the package.json does not mark `react-i18next` as a peer dependency.

# What has been done
- Added `react-i18next` as a peer dependency.