### PR TITLE
Update generateDocument.ts

### DIFF
--- a/src/utils/generateDocument.ts
+++ b/src/utils/generateDocument.ts
@@ -96,7 +96,7 @@ export const generateDocument = async (config: GenDocConfig, fields: Fields) => 
     const convertBlockField = async (field: BlockField, values: Data) => {
         const blockValues = values[field.name];
 
-        if (field.required && !blockValues) {
+        if (!field.required && !blockValues) {
             return [];
         }
 

--- a/src/utils/generateDocument.ts
+++ b/src/utils/generateDocument.ts
@@ -96,8 +96,12 @@ export const generateDocument = async (config: GenDocConfig, fields: Fields) => 
     const convertBlockField = async (field: BlockField, values: Data) => {
         const blockValues = values[field.name];
 
-        if (!field.required && !blockValues) {
+        if (field.required && !blockValues) {
             return [];
+        }
+        
+        if (!field.required && !blockValues) {
+            return undefined;
         }
 
         return Promise.all(


### PR DESCRIPTION
Return an empty array when the field is NOT REQUIRED. blockValues can be null (Literally not set) when it is not required so you should check if it is NOT required.

Otherwise... You will get this bug in production when the collection has a NON REQUIRED blocks field, but no blocks.

![image](https://github.com/pemedia/payload-visual-editor/assets/37052068/0eaec64d-62ee-4403-8691-a98268252566)
