### PR TITLE
fix(generateDocument): process block fields

### DIFF
--- a/src/utils/generateDocument.ts
+++ b/src/utils/generateDocument.ts
@@ -106,7 +106,8 @@ export const generateDocument = async (config: GenDocConfig, fields: Fields) => 
 
         return Promise.all(
             blockValues.map(async (value: Data) => {
-                const fields = getBlock(field.blocks, value.blockType).fields as FieldAffectingData[];
+                const block = getBlock(field.blocks, value.blockType);
+                const fields = getAllFields(block.fields) as FieldAffectingData[];
 
                 const result: any = {
                     id: value.id,


### PR DESCRIPTION
Thanks for the awesome plugin!

We've noticed that the preview breaks if you use presentiational fields like ui, collapsible in a block. This PR aims to fix that.